### PR TITLE
Import November data; Add import script

### DIFF
--- a/data/index.ts
+++ b/data/index.ts
@@ -1,190 +1,189 @@
 import { CalendarItem } from '@/utils/types'
 
-export const data: CalendarItem[] = [
-  {
-    day: 'Sunday',
-    date: 'Oct 1st',
-    name: 'Tacos Al Sabor',
-    url: ''
-  },
-  {
-    day: 'Monday',
-    date: 'Oct 2nd',
-    name: 'Rolling Italian & HipPOPs',
-    url: 'https://rollingitalianonline.square.site'
-  },
-  {
-    day: 'Tuesday',
-    date: 'Oct 3rd',
-    name: 'Revolver',
-    url: 'https://www.revolverfoodtruck.com/menus'
-  },
-  {
-    day: 'Wednesday',
-    date: 'Oct 4th',
-    name: ' Samos Grill',
-    url: 'https://roaminghunger.com/samos-grill/'
-  },
-  {
-    day: 'Thursday',
-    date: 'Oct 5th',
-    name: 'Woodhill Small Batch BBQ',
-    url: 'http://woodhillsmallbatchbbq.com/'
-  },
-  {
-    day: 'Friday',
-    date: 'Oct 6th',
-    name: 'Los Dos',
-    url: 'http://www.los2potrillos.com/'
-  },
-  {
-    day: 'Saturday',
-    date: 'Oct 7th',
-    name: 'Los Chamacos',
-    url: 'https://www.facebook.com/people/El-chamacos-taco-dealer-my-legacy/100057675699460/'
-  },
-  {
-    day: 'Sunday',
-    date: 'Oct 8th',
-    name: 'No Food Truck',
-    url: ''
-  },
-  {
-    day: 'Monday',
-    date: 'Oct 9th',
-    name: 'No Food Truck',
-    url: ''
-  },
-  {
-    day: 'Tuesday',
-    date: 'Oct 10th',
-    name: 'Rag Bag BIstro',
-    url: ''
-  },
-  {
-    day: 'Wednesday',
-    date: 'Oct 11th',
-    name: 'Arepa’s Caribbean Food & Simply Le Crepes',
-    url: ''
-  },
-  {
-    day: 'Thursday',
-    date: 'Oct 12th',
-    name: 'PinkTank',
-    url: 'https://www.eatpinkgettanked.com/'
-  },
-  {
-    day: 'Friday',
-    date: 'Oct 13th',
-    name: 'Schnitzelwirts ',
-    url: ''
-  },
-  {
-    day: 'Saturday',
-    date: 'Oct 14th',
-    name: ' Originals by Greeks ',
-    url: ''
-  },
-  {
-    day: 'Sunday',
-    date: 'Oct 15th',
-    name: 'MIke’s Coneys (3pm - 8 pm)',
-    url: ''
-  },
-  {
-    day: 'Monday',
-    date: 'Oct 16th',
-    name: 'Seasoned Swine & HipPops',
-    url: ''
-  },
-  {
-    day: 'Tuesday',
-    date: 'Oct 17th',
-    name: 'Sizzle',
-    url: 'https://www.sizzlefoodtruck.com/menu.html'
-  },
-  {
-    day: 'Wednesday',
-    date: 'Oct 18th',
-    name: 'Isan Thai',
-    url: ''
-  },
-  {
-    day: 'Thursday',
-    date: 'Oct 19th',
-    name: 'Woodhill Small Batch BBQ',
-    url: 'http://woodhillsmallbatchbbq.com/'
-  },
-  {
-    day: 'Friday',
-    date: 'Oct 20th',
-    name: 'Los Dos',
-    url: 'http://www.los2potrillos.com/'
-  },
-  {
-    day: 'Saturday',
-    date: 'Oct 21st',
-    name: 'Arepa’s Caribbean Food',
-    url: ''
-  },
-  {
-    day: 'Sunday',
-    date: 'Oct 22nd',
-    name: 'Tacos Al Sabor',
-    url: ''
-  },
-  {
-    day: 'Monday',
-    date: 'Oct 23rd',
-    name: 'Big Belly BBQ',
-    url: ''
-  },
-  {
-    day: 'Tuesday',
-    date: 'Oct 24th',
-    name: 'Rag Bag Bistro',
-    url: ''
-  },
-  {
-    day: 'Wednesday',
-    date: 'Oct 25th',
-    name: 'Revolver',
-    url: 'https://www.revolverfoodtruck.com/menus'
-  },
-  {
-    day: 'Thursday',
-    date: 'Oct 26th',
-    name: 'Rolling Italian',
-    url: 'https://rollingitalianonline.square.site/'
-  },
-  {
-    day: 'Friday',
-    date: 'Oct 27th',
-    name: 'Seasoned Swine',
-    url: 'https://www.seasonedswine.com/food-truck'
-  },
-  {
-    day: 'Saturday',
-    date: 'Oct 28th',
-    name: 'TBD & Simply Le Crepes',
-    url: ''
-  },
-  {
-    day: 'Sunday',
-    date: 'Oct 29th',
-    name: 'Market 86',
-    url: 'https://www.facebook.com/franktownmarket86/'
-  },
-  {
-    day: 'Monday',
-    date: 'Oct 30th',
-    name: 'TBD',
-    url: ''
-  },
-  {
-    day: 'Tuesday',
-    date: 'Oct 31st',
-    name: 'Ez Eats',
-    url: ''
-  }
-]
+export const data: CalendarItem[] = [{
+  "date": "Oct 1",
+  "name": "Tacos Al Sabor",
+  "day": "Sunday",
+  "url": ""
+},
+{
+  "date": "Oct 2",
+  "name": "Rolling Italian & HipPOPs",
+  "day": "Monday",
+  "url": "https://rollingitalianonline.square.site"
+},
+{
+  "date": "Oct 3",
+  "name": "Revolver",
+  "day": "Tuesday",
+  "url": "https://www.revolverfoodtruck.com/menus"
+},
+{
+  "date": "Oct 4",
+  "name": " Samos Grill",
+  "day": "Wednesday",
+  "url": "https://roaminghunger.com/samos-grill/"
+},
+{
+  "date": "Oct 5",
+  "name": "Woodhill Small Batch BBQ",
+  "day": "Thursday",
+  "url": "http://woodhillsmallbatchbbq.com/"
+},
+{
+  "date": "Oct 6",
+  "name": "Los Dos",
+  "day": "Friday",
+  "url": "http://www.los2potrillos.com/"
+},
+{
+  "date": "Oct 7",
+  "name": "Los Chamacos",
+  "day": "Saturday",
+  "url": "https://www.facebook.com/people/El-chamacos-taco-dealer-my-legacy/100057675699460/"
+},
+{
+  "date": "Oct 8",
+  "name": "No Food Truck",
+  "day": "Sunday",
+  "url": ""
+},
+{
+  "date": "Oct 9",
+  "name": "No Food Truck",
+  "day": "Monday",
+  "url": ""
+},
+{
+  "date": "Oct 10",
+  "name": "Rag Bag BIstro",
+  "day": "Tuesday",
+  "url": ""
+},
+{
+  "date": "Oct 11",
+  "name": "Arepa's Caribbean Food & Simply Le Crepes",
+  "day": "Wednesday",
+  "url": ""
+},
+{
+  "date": "Oct 12",
+  "name": "PinkTank",
+  "day": "Thursday",
+  "url": "https://www.eatpinkgettanked.com/"
+},
+{
+  "date": "Oct 13",
+  "name": "Schnitzelwirts ",
+  "day": "Friday",
+  "url": ""
+},
+{
+  "date": "Oct 14",
+  "name": " Originals by Greeks ",
+  "day": "Saturday",
+  "url": ""
+},
+{
+  "date": "Oct 15",
+  "name": "MIke's Coneys (3pm - 8 pm)",
+  "day": "Sunday",
+  "url": ""
+},
+{
+  "date": "Oct 16",
+  "name": "Seasoned Swine & HipPops",
+  "day": "Monday",
+  "url": ""
+},
+{
+  "date": "Oct 17",
+  "name": "Sizzle",
+  "day": "Tuesday",
+  "url": "https://www.sizzlefoodtruck.com/menu.html"
+},
+{
+  "date": "Oct 18",
+  "name": "Isan Thai",
+  "day": "Wednesday",
+  "url": ""
+},
+{
+  "date": "Oct 19",
+  "name": "Woodhill Small Batch BBQ",
+  "day": "Thursday",
+  "url": "http://woodhillsmallbatchbbq.com/"
+},
+{
+  "date": "Oct 20",
+  "name": "Los Dos",
+  "day": "Friday",
+  "url": "http://www.los2potrillos.com/"
+},
+{
+  "date": "Oct 21",
+  "name": "Arepa's Caribbean Food",
+  "day": "Saturday",
+  "url": ""
+},
+{
+  "date": "Oct 22",
+  "name": "Tacos Al Sabor",
+  "day": "Sunday",
+  "url": ""
+},
+{
+  "date": "Oct 23",
+  "name": "Big Belly BBQ",
+  "day": "Monday",
+  "url": ""
+},
+{
+  "date": "Oct 24",
+  "name": "Rag Bag Bistro",
+  "day": "Tuesday",
+  "url": ""
+},
+{
+  "date": "Oct 25",
+  "name": "Revolver",
+  "day": "Wednesday",
+  "url": "https://www.revolverfoodtruck.com/menus"
+},
+{
+  "date": "Oct 26",
+  "name": "Rolling Italian",
+  "day": "Thursday",
+  "url": "https://rollingitalianonline.square.site/"
+},
+{
+  "date": "Oct 27",
+  "name": "Seasoned Swine",
+  "day": "Friday",
+  "url": "https://www.seasonedswine.com/food-truck"
+},
+{
+  "date": "Oct 28",
+  "name": "TBD & Simply Le Crepes",
+  "day": "Saturday",
+  "url": ""
+},
+{
+  "date": "Oct 29",
+  "name": "Market 86",
+  "day": "Sunday",
+  "url": "https://www.facebook.com/franktownmarket86/"
+},
+{
+  "date": "Oct 30",
+  "name": "TBD",
+  "day": "Monday",
+  "url": ""
+},
+{
+  "date": "Oct 31",
+  "name": "Ez Eats",
+  "day": "Tuesday",
+  "url": ""
+}]; 
+

--- a/data/index.ts
+++ b/data/index.ts
@@ -1,189 +1,184 @@
 import { CalendarItem } from '@/utils/types'
 
-export const data: CalendarItem[] = [{
-  "date": "Oct 1",
-  "name": "Tacos Al Sabor",
-  "day": "Sunday",
-  "url": ""
-},
-{
-  "date": "Oct 2",
-  "name": "Rolling Italian & HipPOPs",
-  "day": "Monday",
-  "url": "https://rollingitalianonline.square.site"
-},
-{
-  "date": "Oct 3",
-  "name": "Revolver",
-  "day": "Tuesday",
-  "url": "https://www.revolverfoodtruck.com/menus"
-},
-{
-  "date": "Oct 4",
-  "name": " Samos Grill",
-  "day": "Wednesday",
-  "url": "https://roaminghunger.com/samos-grill/"
-},
-{
-  "date": "Oct 5",
-  "name": "Woodhill Small Batch BBQ",
-  "day": "Thursday",
-  "url": "http://woodhillsmallbatchbbq.com/"
-},
-{
-  "date": "Oct 6",
-  "name": "Los Dos",
-  "day": "Friday",
-  "url": "http://www.los2potrillos.com/"
-},
-{
-  "date": "Oct 7",
-  "name": "Los Chamacos",
-  "day": "Saturday",
-  "url": "https://www.facebook.com/people/El-chamacos-taco-dealer-my-legacy/100057675699460/"
-},
-{
-  "date": "Oct 8",
-  "name": "No Food Truck",
-  "day": "Sunday",
-  "url": ""
-},
-{
-  "date": "Oct 9",
-  "name": "No Food Truck",
-  "day": "Monday",
-  "url": ""
-},
-{
-  "date": "Oct 10",
-  "name": "Rag Bag BIstro",
-  "day": "Tuesday",
-  "url": ""
-},
-{
-  "date": "Oct 11",
-  "name": "Arepa's Caribbean Food & Simply Le Crepes",
-  "day": "Wednesday",
-  "url": ""
-},
-{
-  "date": "Oct 12",
-  "name": "PinkTank",
-  "day": "Thursday",
-  "url": "https://www.eatpinkgettanked.com/"
-},
-{
-  "date": "Oct 13",
-  "name": "Schnitzelwirts ",
-  "day": "Friday",
-  "url": ""
-},
-{
-  "date": "Oct 14",
-  "name": " Originals by Greeks ",
-  "day": "Saturday",
-  "url": ""
-},
-{
-  "date": "Oct 15",
-  "name": "MIke's Coneys (3pm - 8 pm)",
-  "day": "Sunday",
-  "url": ""
-},
-{
-  "date": "Oct 16",
-  "name": "Seasoned Swine & HipPops",
-  "day": "Monday",
-  "url": ""
-},
-{
-  "date": "Oct 17",
-  "name": "Sizzle",
-  "day": "Tuesday",
-  "url": "https://www.sizzlefoodtruck.com/menu.html"
-},
-{
-  "date": "Oct 18",
-  "name": "Isan Thai",
-  "day": "Wednesday",
-  "url": ""
-},
-{
-  "date": "Oct 19",
-  "name": "Woodhill Small Batch BBQ",
-  "day": "Thursday",
-  "url": "http://woodhillsmallbatchbbq.com/"
-},
-{
-  "date": "Oct 20",
-  "name": "Los Dos",
-  "day": "Friday",
-  "url": "http://www.los2potrillos.com/"
-},
-{
-  "date": "Oct 21",
-  "name": "Arepa's Caribbean Food",
-  "day": "Saturday",
-  "url": ""
-},
-{
-  "date": "Oct 22",
-  "name": "Tacos Al Sabor",
-  "day": "Sunday",
-  "url": ""
-},
-{
-  "date": "Oct 23",
-  "name": "Big Belly BBQ",
-  "day": "Monday",
-  "url": ""
-},
-{
-  "date": "Oct 24",
-  "name": "Rag Bag Bistro",
-  "day": "Tuesday",
-  "url": ""
-},
-{
-  "date": "Oct 25",
-  "name": "Revolver",
-  "day": "Wednesday",
-  "url": "https://www.revolverfoodtruck.com/menus"
-},
-{
-  "date": "Oct 26",
-  "name": "Rolling Italian",
-  "day": "Thursday",
-  "url": "https://rollingitalianonline.square.site/"
-},
-{
-  "date": "Oct 27",
-  "name": "Seasoned Swine",
-  "day": "Friday",
-  "url": "https://www.seasonedswine.com/food-truck"
-},
-{
-  "date": "Oct 28",
-  "name": "TBD & Simply Le Crepes",
-  "day": "Saturday",
-  "url": ""
-},
-{
-  "date": "Oct 29",
-  "name": "Market 86",
-  "day": "Sunday",
-  "url": "https://www.facebook.com/franktownmarket86/"
-},
-{
-  "date": "Oct 30",
-  "name": "TBD",
-  "day": "Monday",
-  "url": ""
-},
-{
-  "date": "Oct 31",
-  "name": "Ez Eats",
-  "day": "Tuesday",
-  "url": ""
-}]; 
-
+export const data: CalendarItem[] = [
+  {
+    date: 'Nov 1st',
+    name: 'TBD',
+    day: 'Wednesday',
+    url: ''
+  },
+  {
+    date: 'Nov 2nd',
+    name: 'Woodhill Small Batch BBQ',
+    day: 'Thursday',
+    url: 'http://woodhillsmallbatchbbq.com/'
+  },
+  {
+    date: 'Nov 3rd',
+    name: 'Los Dos Potrillos',
+    day: 'Friday',
+    url: 'http://www.los2potrillos.com/'
+  },
+  {
+    date: 'Nov 4th',
+    name: "Still Smokin BBQ, Mike's Coneys & HipPOPs at the Overlook Clubhouse 11:00 am - 2:00 pm; Simply Le Crepes 4:00 pm - 8:00 pm at the Sterling Center",
+    day: 'Saturday',
+    url: ''
+  },
+  {
+    date: 'Nov 5th',
+    name: 'Tacos Al Sabor',
+    day: 'Sunday',
+    url: ''
+  },
+  {
+    date: 'Nov 6th',
+    name: 'Big Belly BBQ',
+    day: 'Monday',
+    url: ''
+  },
+  {
+    date: 'Nov 7th',
+    name: 'Los Chamacos',
+    day: 'Tuesday',
+    url: 'https://www.facebook.com/people/El-chamacos-taco-dealer-my-legacy/100057675699460/'
+  },
+  {
+    date: 'Nov 8th',
+    name: 'Rolling Italian',
+    day: 'Wednesday',
+    url: 'https://rollingitalianonline.square.site/'
+  },
+  {
+    date: 'Nov 9th',
+    name: 'Revolver Food Truck',
+    day: 'Thursday',
+    url: 'https://www.revolverfoodtruck.com/menus'
+  },
+  {
+    date: 'Nov 10th',
+    name: 'Deja Roux',
+    day: 'Friday',
+    url: ''
+  },
+  {
+    date: 'Nov 11th',
+    name: 'Seasoned Swine',
+    day: 'Saturday',
+    url: 'https://www.seasonedswine.com/food-truck'
+  },
+  {
+    date: 'Nov 12th',
+    name: 'TBD',
+    day: 'Sunday',
+    url: ''
+  },
+  {
+    date: 'Nov 13th',
+    name: 'Cirque Kitchen',
+    day: 'Monday',
+    url: ''
+  },
+  {
+    date: 'Nov 14th',
+    name: 'Big Belly BBQ',
+    day: 'Tuesday',
+    url: ''
+  },
+  {
+    date: 'Nov 15th',
+    name: 'Sizzle Food Truck',
+    day: 'Wednesday',
+    url: 'https://www.sizzlefoodtruck.com/menu.html'
+  },
+  {
+    date: 'Nov 16th',
+    name: 'Woodhill Small Batch BBQ',
+    day: 'Thursday',
+    url: 'http://woodhillsmallbatchbbq.com/'
+  },
+  {
+    date: 'Nov 17th',
+    name: 'Los Dos Potrillos',
+    day: 'Friday',
+    url: 'http://www.los2potrillos.com/'
+  },
+  {
+    date: 'Nov 18th',
+    name: 'Isan Thai',
+    day: 'Saturday',
+    url: ''
+  },
+  {
+    date: 'Nov 19th',
+    name: 'Tacos Al Sabor',
+    day: 'Sunday',
+    url: ''
+  },
+  {
+    date: 'Nov 20th',
+    name: 'Samos Grill & HipPOPs',
+    day: 'Monday',
+    url: 'https://roaminghunger.com/samos-grill/'
+  },
+  {
+    date: 'Nov 21st',
+    name: 'Turkish Chef',
+    day: 'Tuesday',
+    url: ''
+  },
+  {
+    date: 'Nov 22nd',
+    name: 'Samos Grill',
+    day: 'Wednesday',
+    url: 'https://roaminghunger.com/samos-grill/'
+  },
+  {
+    date: 'Nov 23rd',
+    name: 'No Truck',
+    day: 'Thursday',
+    url: ''
+  },
+  {
+    date: 'Nov 24th',
+    name: 'No Truck',
+    day: 'Friday',
+    url: ''
+  },
+  {
+    date: 'Nov 25th',
+    name: 'Simply Le Crepes',
+    day: 'Saturday',
+    url: ''
+  },
+  {
+    date: 'Nov 26th',
+    name: 'Rolling Italian',
+    day: 'Sunday',
+    url: 'https://rollingitalianonline.square.site/'
+  },
+  {
+    date: 'Nov 27th',
+    name: 'TBD',
+    day: 'Monday',
+    url: ''
+  },
+  {
+    date: 'Nov 28th',
+    name: 'Sizzle Food Truck',
+    day: 'Tuesday',
+    url: 'https://www.sizzlefoodtruck.com/menu.html'
+  },
+  {
+    date: 'Nov 29th',
+    name: 'Areas Caribbean Food',
+    day: 'Wednesday',
+    url: ''
+  },
+  {
+    date: 'Nov 30th',
+    name: 'High Society Pizza',
+    day: 'Thursday',
+    url: ''
+  }
+]

--- a/data/raw.txt
+++ b/data/raw.txt
@@ -1,0 +1,60 @@
+11/1 - TBD
+
+11/2 - Woodhill Small Batch BBQ
+
+11/3 - Los Dos Potrillos
+
+11/4 - Still Smokin BBQ, Mike's Coneys & HipPOPs at the Overlook Clubhouse 11:00 am - 2:00 pm; Simply Le Crepes 4:00 pm - 8:00 pm at the Sterling Center
+
+11/5 - Tacos Al Sabor
+
+11/6 - Big Belly BBQ
+
+11/7 - Los Chamacos
+
+11/8 - Rolling Italian
+
+11/9 - Revolver Food Truck
+
+11/10 - Deja Roux
+
+11/11 - Seasoned Swine
+
+11/12 - TBD
+
+11/13 - Cirque Kitchen
+
+11/14 - Big Belly BBQ
+
+11/15 - Sizzle Food Truck
+
+11/16 - Woodhill Small Batch BBQ
+
+11/17 - Los Dos Potrillos
+
+11/18 - Isan Thai
+
+11/19 - Tacos Al Sabor
+
+11/20 - Samos Grill & HipPOPs
+
+11/21 - Turkish Chef
+
+11/22 - Samos Grill
+
+11/23 - No Truck
+
+11/24 - No Truck
+
+11/25 - Simply Le Crepes
+
+11/26 - Rolling Italian
+
+11/27 - TBD
+
+11/28 - Sizzle Food Truck
+
+11/29 - Areas Caribbean Food 
+
+11/30 - High Society Pizza
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "clsx": "^1.2.1",
+        "date-fns": "^2.30.0",
         "framer-motion": "^10.11.2",
         "next": "13.3.0",
         "react": "18.2.0",
@@ -33,7 +34,6 @@
       "version": "7.21.0",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.21.0.tgz",
       "integrity": "sha512-xwII0//EObnq89Ji5AKYQaRYiW/nZ3llSv29d49IuxPhKbtJoLP+9QUUZ4nVragQVtaVGeZrpB+ZtG/Pdy/POw==",
-      "dev": true,
       "dependencies": {
         "regenerator-runtime": "^0.13.11"
       },
@@ -1032,6 +1032,21 @@
       "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz",
       "integrity": "sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==",
       "dev": true
+    },
+    "node_modules/date-fns": {
+      "version": "2.30.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz",
+      "integrity": "sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==",
+      "dependencies": {
+        "@babel/runtime": "^7.21.0"
+      },
+      "engines": {
+        "node": ">=0.11"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/date-fns"
+      }
     },
     "node_modules/debug": {
       "version": "4.3.4",
@@ -3539,8 +3554,7 @@
     "node_modules/regenerator-runtime": {
       "version": "0.13.11",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
-      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
-      "dev": true
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg=="
     },
     "node_modules/regexp.prototype.flags": {
       "version": "1.4.3",

--- a/package.json
+++ b/package.json
@@ -6,10 +6,12 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "import-trucks": "node ./script/import-trucks.ts && prettier ./data/index.ts --write"
   },
   "dependencies": {
     "clsx": "^1.2.1",
+    "date-fns": "^2.30.0",
     "framer-motion": "^10.11.2",
     "next": "13.3.0",
     "react": "18.2.0",

--- a/script/import-trucks.ts
+++ b/script/import-trucks.ts
@@ -1,0 +1,54 @@
+const fs = require('fs')
+const { format, parse } = require('date-fns')
+
+const URL_MAP = {
+  'Rolling Italian & HipPOPs': 'https://rollingitalianonline.square.site',
+  Revolver: 'https://www.revolverfoodtruck.com/menus',
+  'Samos Grill': 'https://roaminghunger.com/samos-grill/',
+  'Woodhill Small Batch BBQ': 'http://woodhillsmallbatchbbq.com/',
+  'Los Dos': 'http://www.los2potrillos.com/',
+  'Los Chamacos': 'https://www.facebook.com/people/El-chamacos-taco-dealer-my-legacy/100057675699460/',
+  PinkTank: 'https://www.eatpinkgettanked.com/',
+  Sizzle: 'https://www.sizzlefoodtruck.com/menu.html',
+  'Rolling Italian': 'https://rollingitalianonline.square.site/',
+  'Seasoned Swine': 'https://www.seasonedswine.com/food-truck',
+  'Market 86': 'https://www.facebook.com/franktownmarket86/'
+}
+
+function formatInput(rawInput, dateFormat) {
+  return rawInput.split('\n').reduce((acc, row) => {
+    // Skip blank rows
+    if (!row.trim()) {
+      return acc
+    }
+
+    const [rawDate, rawTruck] = row.split(/-(.*)/s)
+    const date = parse(rawDate, dateFormat, new Date())
+
+    return [
+      ...acc,
+      {
+        date: format(date, 'MMM do'), // May 5th, Dec 23rd, ...
+        name: rawTruck.trim(),
+        day: format(date, 'EEEE'), // Monday, Tuesday, ...
+        url: URL_MAP[rawTruck.trim()] ?? ''
+      }
+    ]
+  }, [])
+}
+
+;(function importData() {
+  const rawData = fs.readFileSync('data/raw.txt', { encoding: 'utf8', flag: 'r' })
+
+  const data = `import { CalendarItem } from '@/utils/types'
+
+  export const data: CalendarItem[] = 
+    ${JSON.stringify(formatInput(rawData, 'M/d'), null, 2)};`
+
+  fs.writeFile(`data/index.ts`, data, function (err) {
+    if (err) {
+      return console.log(err)
+    }
+    console.log('Data updated')
+  })
+})()


### PR DESCRIPTION
## Summary

This updates `data/index.ts` with the latest food truck data as well as adds a script to simplify the import process

### `npm run import-trucks`

This script looks at the file `data/raw.txt` which should be a direct copy-paste from the Sterling Ranch food truck calendar and formats it into a `CalendarItem[]`. 

Caveats:

1. The food truck schedule from the Sterling Ranch website is inconsistent with truck names so it's worth it to scan the output and update the URLs manually for now. For example, you might get any of the below names and the simple map lookup will obviously fail:
    1. Los Dos
    2. Los Dos Potrillos
    3. Los Dos Food Truck
    4. Los Dos and HiPops
 2. The food truck schedule has so far been pretty consistent with date format, but that could easily change since it's just raw text. `formatInput` takes a date format, so you can simply update that to whatever format they change to in the future.

### Testing
Validated that this is working locally:

<img width="545" alt="Screen Shot 2023-11-05 at 9 41 41 AM" src="https://github.com/PixelJanitor/sterlingranchfoodtrucksdotcom/assets/3206804/9617fe7a-4740-4944-9130-4e2a04bb7ea9">